### PR TITLE
feat: добавлен правильный gitignore для файлов изображений

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,80 @@ venv/
 env/
 .venv/
 .env/
+
+# Images and Media Files
+# =====================
+
+# Uploaded images (keep directory structure but ignore files)
+**/uploads/**/*.jpg
+**/uploads/**/*.jpeg
+**/uploads/**/*.png
+**/uploads/**/*.gif
+**/uploads/**/*.bmp
+**/uploads/**/*.webp
+**/uploads/**/*.svg
+**/uploads/**/*.ico
+**/uploads/**/*.tiff
+**/uploads/**/*.tif
+
+# Keep uploads directory structure
+!**/uploads/
+!**/uploads/**/
+!**/uploads/**/.gitkeep
+
+# Media directories
+media/
+static/media/
+public/media/
+assets/media/
+
+# Image cache and temporary files
+*.jpg.tmp
+*.jpeg.tmp
+*.png.tmp
+*.gif.tmp
+*.bmp.tmp
+*.webp.tmp
+*.svg.tmp
+*.ico.tmp
+**/image_cache/
+**/img_cache/
+**/thumbnail_cache/
+**/thumbs/
+
+# Generated images and thumbnails
+**/thumbnails/
+**/thumbs/
+**/resized/
+**/optimized/
+**/compressed/
+
+# Test images (except essential ones)
+**/test_images/
+**/sample_images/
+**/demo_images/
+# Keep benchmark images for YOLO testing
+!backend/prosto_board_volume-main/utils/benchmarks/input/wooden_boards_images/
+
+# Frontend build artifacts with images
+**/dist/**/*.jpg
+**/dist/**/*.jpeg
+**/dist/**/*.png
+**/dist/**/*.gif
+**/dist/**/*.bmp
+**/dist/**/*.webp
+**/dist/**/*.svg
+**/dist/**/*.ico
+
+# Image processing temporary files
+**/processed/
+**/temp_images/
+**/tmp_images/
+*.processed
+*.resized
+*.optimized
+
+# User uploaded content
+user_uploads/
+user_content/
+user_media/

--- a/backend/backend/uploads/.gitkeep
+++ b/backend/backend/uploads/.gitkeep
@@ -1,0 +1,2 @@
+# This file ensures the uploads directory is tracked by git
+# while ignoring the actual uploaded files


### PR DESCRIPTION
## Описание изменений

Добавлен комплексный .gitignore для правильной обработки файлов изображений в проекте.

## Что было сделано

### ✅ Добавленные правила .gitignore:

1. **Загруженные изображения** - игнорируются все форматы изображений в папках uploads (jpg, jpeg, png, gif, bmp, webp, svg, ico, tiff, tif)

2. **Сохранение структуры** - добавлены исключения для сохранения структуры папок uploads и .gitkeep файлов

3. **Медиа директории** - игнорируются стандартные папки media, static/media, public/media, assets/media

4. **Временные файлы** - игнорируются временные файлы изображений (.tmp), кэш изображений, миниатюры

5. **Обработанные изображения** - игнорируются папки с обработанными, сжатыми, оптимизированными изображениями

6. **Тестовые изображения** - игнорируются тестовые изображения, НО сохранены важные benchmark изображения для YOLO

7. **Frontend артефакты** - игнорируются изображения в папках dist после сборки

8. **Пользовательский контент** - игнорируются папки с пользовательскими загрузками

### ✅ Созданные файлы:
- `backend/backend/uploads/.gitkeep` - для сохранения структуры папки uploads

### ✅ Протестировано:
- Тестовые изображения в uploads правильно игнорируются
- Benchmark изображения YOLO НЕ игнорируются (что правильно)
- Структура папок сохраняется

## Результат

Теперь проект правильно обрабатывает файлы изображений - игнорирует загруженные пользователями изображения, но сохраняет важные тестовые данные и структуру папок.

## Файлы изменений

- `.gitignore` - добавлены правила для изображений
- `backend/backend/uploads/.gitkeep` - новый файл для сохранения структуры

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author