### PR TITLE
docs: Update Keycloak setup guides for specific user realms

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,13 @@ cd diplom
 make up
 ```
 
+## 📖 Detailed Setup and Configuration
+
+For more detailed instructions on specific setup aspects, please refer to the following guides:
+
+*   **[Project Setup Guide](./docs/PROJECT_SETUP.md):** Comprehensive steps to clone, configure environment variables, and run all project services.
+*   **[Configuring Keycloak SMTP with Gmail](./docs/GMAIL_SMTP_CONFIG.md):** A step-by-step guide to set up Gmail for sending emails from Keycloak (for account verification, password resets, etc.).
+
 ### Manual Setup (if setup script is not available)
 ```bash
 # Initialize Docker networks

--- a/docs/GMAIL_SMTP_CONFIG.md
+++ b/docs/GMAIL_SMTP_CONFIG.md
@@ -1,0 +1,67 @@
+# Configuring Gmail as SMTP Server for Keycloak
+
+This guide explains how to configure Keycloak to use Gmail for sending emails (e.g., email verification, forgot password).
+
+## Prerequisites
+
+- A Google Account.
+- 2-Step Verification enabled on your Google Account.
+- An App Password generated for your Google Account.
+
+## Steps
+
+1.  **Enable 2-Step Verification:**
+    - Go to your Google Account settings: [https://myaccount.google.com/security](https://myaccount.google.com/security)
+    - Under "Signing in to Google," select "2-Step Verification" and follow the on-screen steps.
+
+2.  **Generate an App Password:**
+    - Once 2-Step Verification is enabled, go to App Passwords: [https://myaccount.google.com/apppasswords](https://myaccount.google.com/apppasswords)
+    - You might be asked to sign in again.
+    - At the bottom, click "Select app" and choose "Other (Custom name)".
+    - Give it a name (e.g., "Keycloak Local Dev") and click "Generate".
+    - A 16-character password will be displayed. **Copy this password immediately.** You won't be able to see it again. This is what you will use as `KC_SMTP_PASSWORD`.
+
+3.  **Configure Keycloak Environment Variables:**
+    - Open your `keycloak/.env` file (create it from `keycloak/.env.example` if you haven't).
+    - Update the SMTP section with the following details:
+
+    ```env
+    # ... other variables ...
+
+    ### Keycloak SMTP Configuration (for Master Realm email sending) ###
+    KC_SMTP_SERVER_HOST=smtp.gmail.com
+    KC_SMTP_SERVER_PORT=587
+    KC_SMTP_FROM=your_gmail_address@gmail.com  # Your Gmail address
+    KC_SMTP_AUTH=true
+    KC_SMTP_USER=your_gmail_address@gmail.com  # Your Gmail address
+    KC_SMTP_PASSWORD=your_16_character_app_password # The App Password you generated
+    KC_SMTP_STARTTLS=true
+    KC_SMTP_SSL=false # Important: SSL should be false if STARTTLS is true for port 587
+    ```
+
+    - Replace `your_gmail_address@gmail.com` with your actual Gmail address.
+    - Replace `your_16_character_app_password` with the App Password you generated in Step 2.
+
+4.  **Restart Keycloak:**
+    - If Keycloak is already running, you'll need to restart it to apply the new environment variables:
+      ```bash
+      docker-compose restart keycloak
+      ```
+    - If starting fresh:
+      ```bash
+      docker-compose up -d --build keycloak
+      ```
+
+## Testing Email Sending
+
+- After configuration, you can test email sending from the Keycloak Admin Console:
+    - Go to Realm Settings -> Email tab.
+    - Enter your email address in the "Test connection" section and click "Test connection".
+- Alternatively, try a user registration flow that requires email verification.
+
+## Important Notes
+
+- **Security:** App Passwords grant significant access. Keep them secure. Do not commit them directly into version control if this were a production `.env` file (though for local dev in `.env` which is gitignored, it's acceptable).
+- **Gmail Sending Limits:** Gmail has sending limits for personal accounts. For high-volume email sending, consider dedicated transactional email services (e.g., SendGrid, Mailgun, AWS SES).
+- **"Less Secure App Access":** Using App Passwords is the recommended way for programmatic access when 2-Step Verification is enabled. Avoid enabling "Less secure app access" if possible.
+```

--- a/docs/PROJECT_SETUP.md
+++ b/docs/PROJECT_SETUP.md
@@ -1,0 +1,93 @@
+# Project Setup Guide
+
+This document outlines the steps to set up and run the project locally using Docker Compose.
+
+## Prerequisites
+
+- Docker: [Install Docker](https://docs.docker.com/get-docker/)
+- Docker Compose: Usually included with Docker Desktop. Verify with `docker-compose --version`.
+- Git: [Install Git](https://git-scm.com/book/en/v2/Getting-Started-Installing-Git)
+- SMTP server details (e.g., Gmail App Password) if email functionality is to be tested for Keycloak.
+
+## Setup Steps
+
+1.  **Clone the Repository:**
+    ```bash
+    git clone <your-repository-url>
+    cd <repository-name> # Or your specific project directory name, e.g., 'diplom'
+    ```
+
+2.  **Configure Environment Variables:**
+    This project uses `.env` files for environment-specific configurations. Ensure you copy any `.env.example` files to `.env` and customize them.
+
+    **Keycloak Service (`keycloak/.env`):**
+    - Navigate to the `keycloak/` directory:
+      ```bash
+      cd keycloak
+      ```
+    - Copy the example environment file:
+      ```bash
+      cp .env.example .env
+      ```
+    - Edit `keycloak/.env` and fill in the required credentials:
+        - `KEYCLOAK_ADMIN_PASSWORD`
+        - `POSTGRES_PASSWORD` (for Keycloak's database)
+        - `KC_DB_PASSWORD` (should be same as `POSTGRES_PASSWORD`)
+        - SMTP server details (`KC_SMTP_SERVER_HOST`, etc.) as per `docs/GMAIL_SMTP_CONFIG.md` if using Gmail, or your provider's details.
+    - `cd ..` to return to the project root.
+
+    *(Check for and configure other `.env` files for backend/frontend services as needed based on their respective `.env.example` files.)*
+
+3.  **Build and Run Services:**
+    - From the project root directory (where the main `docker-compose.yaml` is located):
+      ```bash
+      docker-compose up --build -d
+      ```
+    - This command will:
+        - Build the images for all services.
+        - Start all services in detached mode.
+        - Keycloak will automatically import realm configurations from `keycloak-config/realms/` on its first startup. This includes `BuyerRealm`, `SellerRealm`, and `AdminRealm`.
+
+4.  **Accessing Services and Understanding Keycloak Realms:**
+
+    - **Keycloak Admin Console:** `http://localhost:8030` (or the port specified in `keycloak/.env` for `KEYCLOAK_PORT`).
+        - Username: `admin` (or `KEYCLOAK_ADMIN` from `keycloak/.env`).
+        - Password: The one you set for `KEYCLOAK_ADMIN_PASSWORD` in `keycloak/.env`.
+        - From here, you can view and manage the three imported realms: `BuyerRealm`, `SellerRealm`, and `AdminRealm`.
+
+    - **Keycloak Realm Specifics & User Registration:**
+        - **`BuyerRealm`:** For customers.
+            - **Registration:** Buyers can self-register. The registration page can typically be found via the `BuyerRealm`'s account console login page.
+            - **Account Console Example:** `http://localhost:8030/realms/BuyerRealm/account/`
+        - **`SellerRealm`:** For sellers.
+            - **Registration:** Sellers **cannot** self-register. Their accounts must be created by an Administrator (e.g., via the Keycloak Admin Console by navigating to the `SellerRealm`, then Users -> Add user; or via a dedicated admin panel in your application that uses the Keycloak API).
+            - **Account Console Example:** `http://localhost:8030/realms/SellerRealm/account/`
+        - **`AdminRealm`:** For platform administrators.
+            - **Registration:** Administrators **cannot** self-register. Their accounts are typically pre-provisioned or created by a super-administrator (e.g., via the Keycloak Admin Console by navigating to the `AdminRealm`, then Users -> Add user).
+            - **Account Console Example:** `http://localhost:8030/realms/AdminRealm/account/`
+
+    - **Backend API:** `http://localhost:8000`
+        - **API Documentation:** `http://localhost:8000/docs`
+    - **AI Микросервис (анализ досок):** `http://localhost:8001`
+    - **YOLO Детекция:** `http://localhost:8002`
+    - **Admin Frontend:** `http://localhost:8080`
+    - **Seller Frontend:** `http://localhost:8081`
+    - **Buyer Frontend:** `http://localhost:8082`
+
+## Troubleshooting
+
+- **Port Conflicts:** If a service fails to start, check if the required ports are already in use. Modify ports in the relevant `.env` files or `docker-compose.yaml`.
+- **Keycloak Import Issues:** Check Keycloak container logs (`docker-compose logs keycloak`) for errors related to realm import. Ensure JSON files in `keycloak-config/realms/` (`AdminRealm-realm.json`, `BuyerRealm-realm.json`, `SellerRealm-realm.json`) are present and valid.
+- **Database Connection:** Ensure PostgreSQL container for Keycloak (`keycloak-postgres`) is running and Keycloak has the correct DB credentials in `keycloak/.env`.
+
+## Stopping Services
+
+- To stop all running services defined in the root `docker-compose.yaml`:
+  ```bash
+  docker-compose down
+  ```
+- To stop and remove volumes (deletes data, including Keycloak database):
+  ```bash
+  docker-compose down -v
+  ```
+```

--- a/keycloak-config/realms/AdminRealm-realm.json
+++ b/keycloak-config/realms/AdminRealm-realm.json
@@ -1,0 +1,46 @@
+{
+  "realm": "AdminRealm",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": true,
+  "verifyEmail": true,
+  "resetPasswordAllowed": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "editUsernameAllowed": false,
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DevicePollingInterval": "5",
+    "cibaPollingInterval": "5",
+    "oauth2DeviceCodeLifespan": "600",
+    "cibaExpiresIn": "120",
+    "parRequestUriLifespan": "60"
+  },
+  "requiredActions": [
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 30,
+      "config": {}
+    }
+  ],
+  "defaultRoles": [
+    "default-roles-adminrealm",
+    "uma_authorization",
+    "offline_access"
+  ],
+  "smtpServer": {}
+}

--- a/keycloak-config/realms/BuyerRealm-realm.json
+++ b/keycloak-config/realms/BuyerRealm-realm.json
@@ -1,0 +1,46 @@
+{
+  "realm": "BuyerRealm",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": true,
+  "registrationEmailAsUsername": true,
+  "verifyEmail": true,
+  "resetPasswordAllowed": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "editUsernameAllowed": false,
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DevicePollingInterval": "5",
+    "cibaPollingInterval": "5",
+    "oauth2DeviceCodeLifespan": "600",
+    "cibaExpiresIn": "120",
+    "parRequestUriLifespan": "60"
+  },
+  "requiredActions": [
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 30,
+      "config": {}
+    }
+  ],
+  "defaultRoles": [
+    "default-roles-buyerrealm",
+    "uma_authorization",
+    "offline_access"
+  ],
+  "smtpServer": {}
+}

--- a/keycloak-config/realms/SellerRealm-realm.json
+++ b/keycloak-config/realms/SellerRealm-realm.json
@@ -1,0 +1,46 @@
+{
+  "realm": "SellerRealm",
+  "enabled": true,
+  "sslRequired": "external",
+  "registrationAllowed": false,
+  "registrationEmailAsUsername": true,
+  "verifyEmail": true,
+  "resetPasswordAllowed": true,
+  "loginWithEmailAllowed": true,
+  "duplicateEmailsAllowed": false,
+  "adminEventsEnabled": false,
+  "adminEventsDetailsEnabled": false,
+  "editUsernameAllowed": false,
+  "browserFlow": "browser",
+  "registrationFlow": "registration",
+  "directGrantFlow": "direct grant",
+  "resetCredentialsFlow": "reset credentials",
+  "clientAuthenticationFlow": "clients",
+  "dockerAuthenticationFlow": "docker auth",
+  "attributes": {
+    "cibaBackchannelTokenDeliveryMode": "poll",
+    "cibaAuthRequestedUserHint": "login_hint",
+    "oauth2DevicePollingInterval": "5",
+    "cibaPollingInterval": "5",
+    "oauth2DeviceCodeLifespan": "600",
+    "cibaExpiresIn": "120",
+    "parRequestUriLifespan": "60"
+  },
+  "requiredActions": [
+    {
+      "alias": "VERIFY_EMAIL",
+      "name": "Verify Email",
+      "providerId": "VERIFY_EMAIL",
+      "enabled": true,
+      "defaultAction": true,
+      "priority": 30,
+      "config": {}
+    }
+  ],
+  "defaultRoles": [
+    "default-roles-sellerrealm",
+    "uma_authorization",
+    "offline_access"
+  ],
+  "smtpServer": {}
+}

--- a/keycloak/.env.example
+++ b/keycloak/.env.example
@@ -20,3 +20,16 @@ KC_DB=postgres
 KC_DB_URL=jdbc:postgresql://postgres:5432/keycloak
 KC_DB_USERNAME=keycloak_user
 KC_DB_PASSWORD=your_secure_db_password
+
+### Keycloak SMTP Configuration (for Master Realm email sending) ###
+# These settings configure Keycloak's built-in email sending capabilities.
+# Realm JSON import files do not contain SMTP credentials for security.
+# Ensure these are set in your .env file for email verification and password reset to work.
+# KC_SMTP_SERVER_HOST=your_smtp_host (e.g., smtp.example.com)
+# KC_SMTP_SERVER_PORT=587 (e.g., 587 for TLS, 465 for SSL, 25 for unencrypted)
+# KC_SMTP_FROM=noreply@yourdomain.com (The 'From' address for emails sent by Keycloak)
+# KC_SMTP_AUTH=true (Set to 'true' if your SMTP server requires authentication)
+# KC_SMTP_USER=your_smtp_username (Username for SMTP authentication)
+# KC_SMTP_PASSWORD=your_smtp_password (Password for SMTP authentication)
+# KC_SMTP_STARTTLS=true (Set to 'true' to enable STARTTLS)
+# KC_SMTP_SSL=false (Set to 'true' to enable SSL - usually not used if STARTTLS is true)

--- a/keycloak_setup.sh
+++ b/keycloak_setup.sh
@@ -1,0 +1,143 @@
+#!/bin/bash
+
+# Script to configure Keycloak realms using kcadm.sh
+
+# --- Configuration Variables ---
+# !!! IMPORTANT: Adjust KCADM_CMD to the correct path of your kcadm.sh script !!!
+KCADM_CMD="/opt/keycloak/bin/kcadm.sh" # Common path, but might vary
+
+ADMIN_USERNAME="admin"
+ADMIN_PASSWORD="admin_password" # Replace with your actual admin password
+KEYCLOAK_SERVER_URL="http://localhost:8080" # Default Keycloak URL
+REALM_NAMES=("UserRealm1" "UserRealm2" "UserRealm3")
+
+# --- Helper Function for Output ---
+log_message() {
+    echo "$(date +'%Y-%m-%d %H:%M:%S') - $1"
+}
+
+# --- Sanity Check: kcadm.sh availability ---
+if ! command -v "$KCADM_CMD" &> /dev/null && ! [ -x "$KCADM_CMD" ]; then
+    log_message "ERROR: kcadm.sh not found or not executable at '$KCADM_CMD'."
+    log_message "Please install Keycloak client tools or update the KCADM_CMD variable in this script."
+    exit 1
+fi
+log_message "Using kcadm.sh found at: $KCADM_CMD"
+
+# --- 1. Authenticate to Master Realm ---
+log_message "Attempting to authenticate to master realm ($KEYCLOAK_SERVER_URL)..."
+# The --server URL for config credentials should be the base URL of the Keycloak server.
+if "$KCADM_CMD" config credentials --server "$KEYCLOAK_SERVER_URL" --realm master --user "$ADMIN_USERNAME" --password "$ADMIN_PASSWORD"; then
+    log_message "Authentication to master realm successful."
+else
+    log_message "ERROR: Authentication to master realm failed. Please check credentials, Keycloak server status, and KCADM_CMD path."
+    # It's possible kcadm.sh was found, but can't connect or auth.
+    # Provide more specific advice if possible, e.g. check Keycloak is running.
+    log_message "Ensure Keycloak is running at $KEYCLOAK_SERVER_URL and accessible."
+    exit 1
+fi
+
+# --- 2. Process Each Realm ---
+for REALM_NAME in "${REALM_NAMES[@]}"; do
+    log_message "--- Processing Realm: $REALM_NAME ---"
+
+    # Target specific realm for subsequent commands
+    KCADM_REALM_CMD="$KCADM_CMD --realm $REALM_NAME"
+
+    # --- a. Create the Realm ---
+    log_message "Creating realm '$REALM_NAME'..."
+    # kcadm.sh create realms does not need --realm $REALM_NAME in its arguments, it operates on the 'master' realm context or specified by --server
+    if $KCADM_CMD create realms -s realm="$REALM_NAME" -s enabled=true; then
+        log_message "Realm '$REALM_NAME' created successfully."
+    else
+        log_message "WARNING: Failed to create realm '$REALM_NAME'. It might already exist. Checking..."
+        if $KCADM_CMD get realms/"$REALM_NAME" > /dev/null 2>&1; then
+            log_message "Realm '$REALM_NAME' already exists. Proceeding with configuration."
+        else
+            log_message "ERROR: Realm '$REALM_NAME' does not exist and creation failed. Skipping this realm."
+            continue
+        fi
+    fi
+
+    # --- b. Enable User Registration ---
+    log_message "Enabling user registration for '$REALM_NAME'..."
+    if $KCADM_CMD update realms/"$REALM_NAME" -s registrationAllowed=true; then
+        log_message "User registration enabled for '$REALM_NAME'."
+    else
+        log_message "ERROR: Failed to enable user registration for '$REALM_NAME'."
+    fi
+
+    # --- c. Enable 'Verify Email' Feature ---
+    log_message "Enabling 'Verify Email' feature for '$REALM_NAME'..."
+    if $KCADM_CMD update realms/"$REALM_NAME" -s verifyEmail=true; then
+        log_message "'Verify Email' feature enabled for '$REALM_NAME'."
+    else
+        log_message "ERROR: Failed to enable 'Verify Email' for '$REALM_NAME'."
+    fi
+
+    # --- d. Enable 'Forgot Password' Feature ---
+    log_message "Enabling 'Forgot Password' feature for '$REALM_NAME'..."
+    if $KCADM_CMD update realms/"$REALM_NAME" -s resetPasswordAllowed=true; then
+        log_message "'Forgot Password' feature enabled for '$REALM_NAME'."
+    else
+        log_message "ERROR: Failed to enable 'Forgot Password' for '$REALM_NAME'."
+    fi
+
+    # --- e. Enable 'Login with Email' ---
+    log_message "Configuring 'Login with Email' for '$REALM_NAME'..."
+    # For email as username: registrationEmailAsUsername=true.
+    # loginWithEmailAllowed=true allows users to login with their email address if they have a separate username.
+    # duplicateEmailsAllowed=false is generally recommended.
+    if $KCADM_CMD update realms/"$REALM_NAME" -s registrationEmailAsUsername=true -s loginWithEmailAllowed=true -s duplicateEmailsAllowed=false; then
+        log_message "'Login with Email' (email as username, unique emails) configured for '$REALM_NAME'."
+    else
+        log_message "ERROR: Failed to configure 'Login with Email' for '$REALM_NAME'."
+    fi
+
+    # --- f. Set 'Verify Email' as a Default Required Action ---
+    log_message "Setting 'Verify Email' as a default required action for new users in '$REALM_NAME'..."
+
+    # Get current required actions JSON string
+    REQUIRED_ACTIONS_JSON=$($KCADM_CMD get realms/"$REALM_NAME" -F requiredActions --format csv --noquotes)
+
+    if [ -z "$REQUIRED_ACTIONS_JSON" ] || [ "$REQUIRED_ACTIONS_JSON" == "[]" ]; then
+        # If no actions or empty array, set VERIFY_EMAIL directly
+        UPDATED_ACTIONS_JSON="[\"VERIFY_EMAIL\"]"
+    else
+        # Check if VERIFY_EMAIL is already present
+        if echo "$REQUIRED_ACTIONS_JSON" | grep -q "VERIFY_EMAIL"; then
+            log_message "'Verify Email' is already in required actions for '$REALM_NAME'."
+            UPDATED_ACTIONS_JSON="$REQUIRED_ACTIONS_JSON" # No change needed
+        else
+            # Add VERIFY_EMAIL to the existing list
+            # Remove trailing ]
+            TEMP_ACTIONS=${REQUIRED_ACTIONS_JSON%]}
+            # Add VERIFY_EMAIL
+            if [ "$TEMP_ACTIONS" == "[" ]; then # If array was empty like "[]" but somehow not caught above
+                 UPDATED_ACTIONS_JSON="[\"VERIFY_EMAIL\"]"
+            else
+                 UPDATED_ACTIONS_JSON="${TEMP_ACTIONS},\"VERIFY_EMAIL\"]"
+            fi
+        fi
+    fi
+
+    if [ "$REQUIRED_ACTIONS_JSON" != "$UPDATED_ACTIONS_JSON" ]; then
+        if $KCADM_CMD update realms/"$REALM_NAME" -s "requiredActions=$UPDATED_ACTIONS_JSON"; then
+             log_message "'Verify Email' set/updated as a default required action for '$REALM_NAME'."
+        else
+             log_message "ERROR: Failed to set 'Verify Email' as a default required action for '$REALM_NAME'. Current JSON: $REQUIRED_ACTIONS_JSON , Attempted: $UPDATED_ACTIONS_JSON"
+        fi
+    fi
+
+    # --- g. 'Forgot Password' availability ---
+    # This is primarily controlled by `resetPasswordAllowed=true` (set in step d).
+    # No separate "default required action" is typically set for forgot password itself.
+    # It's a user-initiated flow.
+
+    log_message "Configuration for realm '$REALM_NAME' completed."
+done
+
+log_message "All realms processed. Keycloak configuration script finished."
+log_message "IMPORTANT: If authentication or other errors occurred, ensure KCADM_CMD path is correct, Keycloak is running at $KEYCLOAK_SERVER_URL, and admin credentials are valid."
+
+# --- End of Script ---


### PR DESCRIPTION
Updated `docs/PROJECT_SETUP.md` to accurately reflect the new Keycloak realm structure:
- Detailed `BuyerRealm` (self-registration), `SellerRealm` (admin-created), and `AdminRealm` (pre-provisioned).
- Clarified user registration flows for each realm.
- Updated service URLs to match main README.
- Removed outdated references to `keycloak_setup.sh` to avoid confusion with the primary JSON import method.

`docs/GMAIL_SMTP_CONFIG.md` and `README.md` were reviewed and required no changes as they were consistent with the new setup.