### PR TITLE
Fix: Ensure product names are displayed correctly

### DIFF
--- a/frontend/seller/src/components/Products.js
+++ b/frontend/seller/src/components/Products.js
@@ -612,13 +612,13 @@ function Products() {
                       <ProductImage
                         key={`product-list-${product.id}-${imageRefreshKey}`}
                         productId={product.id}
-                        alt={product.title}
+                        alt={product.title || 'Товар без названия'}
                         size="medium"
                       />
                     </td>
                     <td>
                       <div>
-                        <strong>{product.title}</strong>
+                        <strong>{product.title || 'Товар без названия'}</strong>
                         {(product.descrioption || product.description) && (
                           <div style={{ fontSize: '0.8rem', color: '#666', marginTop: '0.25rem' }}>
                             {((product.descrioption || product.description).length > 50)

--- a/frontend/seller/src/components/dashboard/RecentActivity.js
+++ b/frontend/seller/src/components/dashboard/RecentActivity.js
@@ -88,7 +88,7 @@ const RecentProducts = () => {
         <ActivityItem
           key={product.product_uuid || index}
           icon={Package}
-          title={product.name || 'Товар без названия'}
+          title={product.title || 'Товар без названия'}
           description={`${formatCurrencyRu(product.price)} • ${product.volume} м³ • ${product.wood_type_name || 'Тип не указан'}`}
           time={formatDateRu(product.created_at, 'SHORT')}
           color="bg-blue-500"


### PR DESCRIPTION
This commit addresses an issue where product names were sometimes displayed as 'Товар без названия' or not at all in the seller dashboard.

Changes made:
- Modified `RecentActivity.js` to use `product.title` instead of `product.name` for consistency with the API and other components.
- Added a fallback to 'Товар без названия' in both `RecentActivity.js` and `Products.js` in case `product.title` is null or empty. This ensures that a placeholder is always shown if the product name is missing.